### PR TITLE
Problem: Make with docs enabled fails.

### DIFF
--- a/doc/fty-metric-snmp.adoc
+++ b/doc/fty-metric-snmp.adoc
@@ -1,0 +1,51 @@
+Name(7)
+=======
+
+
+NAME
+----
+fty-metric-snmp - Overview of agent for getting measurements using LUA and SNMP
+
+
+SYNOPSIS
+--------
+
+Project fty-metric-snmp aims to ... (short marketing pitch)
+
+It delivers several programs with their respective man pages:
+ fty-metric-snmp.1 fty-metric-snmp-rule.1
+and public classes in a shared library:
+ fty_metric_snmp_server.3 rule_tester.3
+
+Generally you can compile and link against it like this:
+----
+#include <fty_metric_snmp.h>
+
+cc ['flags'] 'files' -lfty_metric_snmp ['libraries']
+----
+
+
+DESCRIPTION
+-----------
+
+This is a skeleton document created by zproject, which will not be
+regenerated automatically (by Makefiles nor project.xml re-parsing).
+You should add hand-written text here to detail whatever applies to
+Linux standard manpage Section 7 (note that other OSes may follow
+a different standard with similar concepts, and extend the recipes
+to package this document into a different section number):
+
+----
+7 Overview, conventions, and miscellaneous :
+    Overviews or descriptions of various topics, conventions
+    and protocols, character set standards, the standard
+    filesystem layout, and miscellaneous other things.
+----
+
+Classes
+~~~~~~~
+
+Something for developers to consider. Note there are separate man
+pages generated for public classes during build with contents taken
+from source code comments.
+

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -63,7 +63,8 @@ bin_PROGRAMS += src/fty-metric-snmp
 src_fty_metric_snmp_CPPFLAGS = ${AM_CPPFLAGS}
 src_fty_metric_snmp_LDADD = ${program_libs}
 src_fty_metric_snmp_SOURCES = src/fty_metric_snmp.c
-src_fty_metric_snmp_config_DATA = src/fty-metric-snmp.cfg
+src_fty_metric_snmp_config_DATA =
+src_fty_metric_snmp_config_DATA += src/fty-metric-snmp.cfg
 src_fty_metric_snmp_configdir = $(sysconfdir)/fty-metric-snmp
 if WITH_SYSTEMD_UNITS
 systemdsystemunit_DATA += src/fty-metric-snmp.service

--- a/src/fty_metric_snmp_selftest.c
+++ b/src/fty_metric_snmp_selftest.c
@@ -138,6 +138,12 @@ main (int argc, char **argv)
             return 1;
         }
     }
+
+    #ifdef NDEBUG
+        printf(" !!! 'assert' macro is disabled, remove NDEBUG from your compilation definitions.\n");
+        printf(" tests will be meaningless.\n");
+    #endif //
+
     if (test) {
         printf ("Running fty-metric-snmp test '%s'...\n", test->testname);
         test->test (verbose);


### PR DESCRIPTION
Solution: Regen; add fty-metric-snmp.adoc to Git because Makefile generated by zproject doesn't work otherwise.

Signed-off-by: Jana Rapava <janarapava@eaton.com>