### PR TITLE
Problem: Uninicialized value causes problems on empty object

### DIFF
--- a/src/vsjson.c
+++ b/src/vsjson.c
@@ -205,7 +205,7 @@ int _vsjson_walk_object (vsjson_t *self, const char *prefix, vsjson_callback_t *
 {
     int result = 0;
     char *locator = NULL;
-    char *key;
+    char *key = NULL;
 
     const char *token = vsjson_next_token (self);
     while (token) {


### PR DESCRIPTION
Solution: Set it to NULL;

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>