### PR TITLE
Problem: Json decode doesn't work with \/ in text.

### DIFF
--- a/src/vsjson.c
+++ b/src/vsjson.c
@@ -407,6 +407,7 @@ char *vsjson_decode_string (const char *string)
             case '"':
                 *dst = *src;
                 ++dst;
+                break;
             case 'b':
                 *dst = '\b';
                 ++dst;


### PR DESCRIPTION
Solution: Add missing break

Signed-off-by: Tomas Halman <Tomas@Halman.net>